### PR TITLE
Hide helper fields

### DIFF
--- a/apparelo/apparelo/doctype/cutting/cutting.json
+++ b/apparelo/apparelo/doctype/cutting/cutting.json
@@ -58,6 +58,9 @@
    "fieldtype": "Column Break"
   },
   {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.__islocal",
+   "depends_on": "eval: doc.docstatus == 0",
    "fieldname": "section_break_3",
    "fieldtype": "Section Break"
   },
@@ -83,6 +86,9 @@
    "label": "Get size combination"
   },
   {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.__islocal",
+   "depends_on": "eval: doc.docstatus == 0",
    "fieldname": "section_break_9",
    "fieldtype": "Section Break"
   },
@@ -114,7 +120,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-01-13 11:07:16.589301",
+ "modified": "2020-01-13 11:48:48.333062",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Cutting",


### PR DESCRIPTION
Hides the _helper fields_ after the Doctype is **submitted**.
Fixes #42