### PR TITLE
Fix priority issues

### DIFF
--- a/apparelo/apparelo/common_scripts.py
+++ b/apparelo/apparelo/common_scripts.py
@@ -5,17 +5,32 @@
 from __future__ import unicode_literals
 import frappe
 import hashlib
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def customize_pf_item_code(item_template, attribute_set, variant_attr, variant):
-    for dia in attribute_set["Dia"]:
-        if dia in variant_attr["Dia"]:
-            if not dia+" Dia" in variant:
-                hash_=hashlib.sha256(variant.replace(item_template,"").encode()).hexdigest()
-                new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Shade'][0].upper(),'').replace('-'+variant_attr['Yarn Count'][0],'').replace('-'+variant_attr['Yarn Category'][0].upper(),'')
-                doc=frappe.get_doc("Item",variant)
-                doc.print_code=new_variant
-                doc.save()
-                renamed_variant=frappe.rename_doc("Item",variant,new_variant+" "+hash_[0:7])
-                return renamed_variant
-            else:
-                return variant
+	for dia in attribute_set["Dia"]:
+		if dia in variant_attr["Dia"]:
+			if not dia+" Dia" in variant:
+				hash_=hashlib.sha256(variant.replace(item_template,"").encode()).hexdigest()
+				new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Shade'][0].upper(),'').replace('-'+variant_attr['Yarn Count'][0],'').replace('-'+variant_attr['Yarn Category'][0].upper(),'')
+				doc=frappe.get_doc("Item",variant)
+				doc.print_code=new_variant
+				doc.save()
+				renamed_variant=frappe.rename_doc("Item",variant,new_variant+" "+hash_[0:7])
+				return renamed_variant
+			else:
+				return variant
+
+def set_custom_fields(update=True):
+	custom_fields = {
+		'Address': [
+			{
+				"fieldname": "location",
+				"fieldtype": "Link",
+				"label": "Location",
+				"options": "Location",
+				"reqd": 1
+				}
+			]
+		}
+	create_custom_fields(custom_fields, ignore_validate=frappe.flags.in_patch, update=update)

--- a/apparelo/apparelo/common_scripts.py
+++ b/apparelo/apparelo/common_scripts.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, Aerele Technologies Private Limited and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+import frappe
+import hashlib
+
+def customize_pf_item_code(item_template, attribute_set, variant_attr, variant):
+    for dia in attribute_set["Dia"]:
+        if dia in variant_attr["Dia"]:
+            if not dia+" Dia" in variant:
+                hash_=hashlib.sha256(variant.replace(item_template,"").encode()).hexdigest()
+                new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Shade'][0].upper(),'').replace('-'+variant_attr['Yarn Count'][0],'').replace('-'+variant_attr['Yarn Category'][0].upper(),'')
+                doc=frappe.get_doc("Item",variant)
+                doc.print_code=new_variant
+                doc.save()
+                renamed_variant=frappe.rename_doc("Item",variant,new_variant+" "+hash_[0:7])
+                return renamed_variant
+            else:
+                return variant

--- a/apparelo/apparelo/common_scripts.py
+++ b/apparelo/apparelo/common_scripts.py
@@ -12,7 +12,7 @@ def customize_pf_item_code(item_template, attribute_set, variant_attr, variant):
 		if dia in variant_attr["Dia"]:
 			if not dia+" Dia" in variant:
 				hash_=hashlib.sha256(variant.replace(item_template,"").encode()).hexdigest()
-				new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Shade'][0].upper(),'').replace('-'+variant_attr['Yarn Count'][0],'').replace('-'+variant_attr['Yarn Category'][0].upper(),'')
+				new_variant=item_template+'-'+variant_attr["Dia"][0]+' Dia'+'-'+variant_attr["Apparelo Colour"][0]+'-'+variant_attr["Knitting Type"][0]
 				doc=frappe.get_doc("Item",variant)
 				doc.print_code=new_variant
 				doc.save()

--- a/apparelo/apparelo/doctype/apparelo_part/apparelo_part.json
+++ b/apparelo/apparelo/doctype/apparelo_part/apparelo_part.json
@@ -29,6 +29,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.__islocal",
    "fieldname": "is_combined",
    "fieldtype": "Check",
    "label": "Is Combined"
@@ -49,7 +50,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-31 16:10:13.306048",
+ "modified": "2020-05-20 19:11:13.596420",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Part",

--- a/apparelo/apparelo/doctype/apparelo_process/apparelo_process.py
+++ b/apparelo/apparelo/doctype/apparelo_process/apparelo_process.py
@@ -13,7 +13,7 @@ def create_apparelo_process(from_process=None,to_process=None):
 	apparelo_process=frappe.get_all("Apparelo Process",fields=['name'])
 	for process_name in apparelo_process:
 		apparelo_process_list.append(process_name.name)
-	processes={'Knitting':['Roll','Roll'],'Dyeing':['Roll','Roll'],'Bleaching':['Roll','Roll'],'Compacting':['Roll','Roll'],'Steaming':['Roll','Roll'],'Roll Printing':['Roll','Roll'],'Cutting':['Roll','Kg'],'Stitching':['Kg','Kg'],'Piece Printing':['Kg','Kg'],'Label Fusing':['Kg','Kg'],'Checking':['Kg','Kg'],'Ironing':['Kg','Kg'],'Packing':['','']}
+	processes={'Knitting':['Bags','Roll'],'Dyeing':['Roll','Roll'],'Bleaching':['Roll','Roll'],'Compacting':['Roll','Roll'],'Steaming':['Roll','Roll'],'Roll Printing':['Roll','Roll'],'Cutting':['Roll','Kg'],'Stitching':['Kg','Kg'],'Piece Printing':['Kg','Kg'],'Label Fusing':['Kg','Kg'],'Checking':['Kg','Kg'],'Ironing':['Kg','Kg'],'Packing':['','']}
 	for process in processes:
 		if from_process and to_process:
 			process_name=from_process+"-"+to_process

--- a/apparelo/apparelo/doctype/compacting/compacting.py
+++ b/apparelo/apparelo/doctype/compacting/compacting.py
@@ -10,7 +10,8 @@ from apparelo.apparelo.utils.utils import is_similar_bom
 from erpnext import get_default_company, get_default_currency
 from erpnext.controllers.item_variant import generate_keyed_value_combinations, get_variant
 from apparelo.apparelo.utils.item_utils import get_attr_dict, get_item_attribute_set, create_variants
-import hashlib
+from apparelo.apparelo.common_scripts import customize_pf_item_code
+
 class Compacting(Document):
 	def on_submit(self):
 		create_item_template()
@@ -26,19 +27,7 @@ class Compacting(Document):
 		for variant in variants:
 			variant_doc=frappe.get_doc("Item",variant)
 			variant_attr = get_attr_dict(variant_doc.attributes)
-			for dia in attribute_set["Dia"]:
-				if dia in variant_attr['Dia']:
-					if not dia+" Dia" in variant:
-						hash_=hashlib.sha256(variant.replace('Compacted Cloth',"").encode()).hexdigest()
-						new_variant=variant.replace(dia,dia+" Dia")
-						doc=frappe.get_doc("Item",variant)
-						doc.print_code=new_variant
-						doc.save()
-						new_variant=new_variant+" "+hash_[0:7]
-						r_variant=frappe.rename_doc("Item",variant,new_variant)
-						new_variants.append(r_variant)
-					else:
-						new_variants.append(variant)
+			new_variants.append(customize_pf_item_code('Compacted Cloth', attribute_set, variant_attr, variant))
 		if len(new_variants)==0:
 			new_variants=variants
 		return new_variants, attribute_set

--- a/apparelo/apparelo/doctype/dc/dc.js
+++ b/apparelo/apparelo/doctype/dc/dc.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('DC', {
 	onload: function(frm) {
+		frm.set_value("company",frappe.defaults.get_default("company"));
 		frm.set_query("supplier", function() {
 			return {
 				query: "apparelo.apparelo.doctype.dc.dc.get_supplier",
@@ -11,7 +12,54 @@ frappe.ui.form.on('DC', {
 				}
 			};
 		});
+		frm.set_query("supplier_address_name", function() {
+			return {
+				filters: {
+					"link_doctype": "Supplier",
+					"link_name": frm.doc.supplier
+				}
+			}
+		});
+		frm.set_query("company_address_name", function() {
+			return {
+				filters: {
+					"link_doctype": "Company",
+					"link_name": frm.doc.company
+				}
+			}
+		});
 	},
+	supplier:function(frm){
+		if (frm.doc.supplier)
+		{
+			frappe.call({
+				method:"apparelo.apparelo.doctype.dc.dc.get_supplier_based_address",
+				args:{supplier: frm.doc.supplier},
+				callback: function(r){
+					if (r.message){
+						frm.set_value("supplier_address_name",r.message)
+					}
+					else {
+						frm.set_value("supplier_address_name","")
+					}
+				}
+			})
+		}
+		refresh_field('supplier_address_name');
+	},
+	location:function(frm){
+		update_company_address(frm);
+		},
+	company:function(frm){
+		update_company_address(frm);
+	},
+	company_address_name: function(frm) {
+		update_supplier_and_company_address(frm.doc.company_address_name, "company_address");
+	},
+	supplier_address_name: function(frm) {
+		update_supplier_and_company_address(frm.doc.supplier_address_name, "supplier_address");
+	},
+	
 	get_items:function(frm) {
 		const set_fields =['item_code','available_quantity','primary_uom','secondary_uom','pf_item_code'];
 		frappe.call({
@@ -58,3 +106,39 @@ frappe.ui.form.on('DC', {
 
 	},
 });
+
+var update_company_address = function(frm){
+	if (frm.doc.location && frm.doc.company)
+	{
+		frappe.call({
+			method:"apparelo.apparelo.doctype.dc.dc.get_location_based_address",
+			args:{location:frm.doc.location, company:frm.doc.company},
+			callback: function(r){
+				if (r.message){
+					frm.set_value("company_address_name",r.message)
+				}
+				else {
+					frm.set_value("company_address_name","")
+				}
+			}
+		})
+	}
+	refresh_field('company_address_name');
+},
+
+var update_supplier_and_company_address = function(address_name,address_field){
+	if(address_field) {
+		frappe.call({
+			method: "frappe.contacts.doctype.address.address.get_address_display",
+			args: {"address_dict": address_field},
+			callback: function(r) {
+				if(r.message) {
+					frm.set_value(address_name, r.message.replace(/<\/?[^>]+>/ig, "\n"))
+				}
+			}
+		})
+	} else {
+		frm.set_value(address_name, "");
+	}
+	refresh_field(address_name);
+}

--- a/apparelo/apparelo/doctype/dc/dc.json
+++ b/apparelo/apparelo/doctype/dc/dc.json
@@ -17,9 +17,16 @@
   "section_break_5",
   "expect_return_items_at",
   "return_materials",
+  "address_and_contact_section",
+  "supplier_address_name",
+  "supplier_address",
+  "column_break_14",
+  "company",
+  "company_address_name",
+  "company_address",
+  "section_break_15",
   "dc_cloth_quantity",
-  "amended_from",
-  "address"
+  "amended_from"
  ],
  "fields": [
   {
@@ -108,15 +115,53 @@
    "label": "Dc Cloth Quantity"
   },
   {
-   "fieldname": "address",
-   "fieldtype": "Long Text",
-   "hidden": 1,
-   "label": "Address"
+   "fieldname": "section_break_15",
+   "fieldtype": "Section Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "address_and_contact_section",
+   "fieldtype": "Section Break",
+   "label": "Address and Contact"
+  },
+  {
+   "fieldname": "column_break_14",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company_address_name",
+   "fieldtype": "Link",
+   "label": "Company Address Name",
+   "options": "Address"
+  },
+  {
+   "fieldname": "company_address",
+   "fieldtype": "Small Text",
+   "label": "Company Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supplier_address_name",
+   "fieldtype": "Link",
+   "label": "Supplier Address Name",
+   "options": "Address"
+  },
+  {
+   "fieldname": "supplier_address",
+   "fieldtype": "Small Text",
+   "label": "Supplier Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-17 15:38:00.715653",
+ "modified": "2020-05-20 16:39:15.362085",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "DC",

--- a/apparelo/apparelo/doctype/dyeing/dyeing.py
+++ b/apparelo/apparelo/doctype/dyeing/dyeing.py
@@ -10,7 +10,8 @@ from apparelo.apparelo.utils.utils import is_similar_bom
 from erpnext import get_default_company, get_default_currency
 from erpnext.controllers.item_variant import generate_keyed_value_combinations, get_variant
 from apparelo.apparelo.utils.item_utils import get_attr_dict, get_item_attribute_set, create_variants
-import hashlib
+from apparelo.apparelo.common_scripts import customize_pf_item_code
+
 class Dyeing(Document):
 	def on_submit(self):
 		create_item_template()
@@ -27,19 +28,7 @@ class Dyeing(Document):
 		for variant in variants:
 			variant_doc=frappe.get_doc("Item",variant)
 			variant_attr = get_attr_dict(variant_doc.attributes)
-			for dia in attribute_set["Dia"]:
-				if dia in variant_attr['Dia']:
-					if not dia+" Dia" in variant:
-						hash_=hashlib.sha256(variant.replace('Dyed Cloth',"").encode()).hexdigest()
-						new_variant=variant.replace(dia,dia+" Dia")
-						doc=frappe.get_doc("Item",variant)
-						doc.print_code=new_variant
-						doc.save()
-						new_variant=new_variant+" "+hash_[0:7]
-						r_variant=frappe.rename_doc("Item",variant,new_variant)
-						new_variants.append(r_variant)
-					else:
-						new_variants.append(variant)
+			new_variants.append(customize_pf_item_code('Dyed Cloth', attribute_set, variant_attr, variant))
 		if len(new_variants)==0:
 			new_variants=variants
 		return new_variants

--- a/apparelo/apparelo/doctype/grn/grn.py
+++ b/apparelo/apparelo/doctype/grn/grn.py
@@ -23,7 +23,7 @@ class GRN(Document):
 		rejected_warehouse= frappe.db.get_value("Warehouse", {'location': self.location,'lot': self.lot,'warehouse_type':'Mistake'},'name')
 		po_doc=frappe.get_doc("Purchase Order",self.po)
 		for item in self.return_materials:
-			item_list.append({"item_code": item.item_code, "received_qty":item.qty, "qty": item.received_qty, "uom": item.uom, "stock_uom": item.uom, "rejected_qty": item.rejected_qty, "schedule_date": add_days(nowdate(), 7), "warehouse": lot_warehouse, "purchase_order": self.po})
+			item_list.append({"item_code": item.item_code, "received_qty": item.received_qty, "qty": item.received_qty - item.rejected_qty, "uom": item.uom, "stock_uom": item.uom, "rejected_qty": item.rejected_qty, "schedule_date": add_days(nowdate(), 7), "warehouse": lot_warehouse, "purchase_order": self.po})
 		pr=frappe.get_doc({
 			"supplier": self.supplier,
 			"rejected_warehouse": rejected_warehouse,

--- a/apparelo/apparelo/doctype/knitting/knitting.py
+++ b/apparelo/apparelo/doctype/knitting/knitting.py
@@ -33,9 +33,9 @@ class Knitting(Document):
 					if not dia+" Dia" in variant:
 						hash_=hashlib.sha256(variant.replace('Knitted Cloth',"").encode()).hexdigest()
 						if variant_attr['Yarn Shade'][0]=='Plain':
-							new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Shade'][0].upper(),'').replace('-'+variant_attr['Yarn Count'][0],'')
+							new_variant='Knitted Cloth-'+variant_attr['Yarn Category'][0]+'-'+variant_attr['Dia'][0]+' Dia'+variant_attr['Knitting Type'][0]+'-'+variant_attr['Apparelo Colour'][0]
 						else:
-							new_variant=variant.replace(dia,dia+" Dia").replace('-'+variant_attr['Yarn Count'][0],'')
+							new_variant='Knitted Cloth-'+variant_attr['Yarn Shade'][0]+'-'+variant_attr['Yarn Category'][0]+'-'+variant_attr['Dia'][0]+' Dia'+variant_attr['Knitting Type'][0]+'-'+variant_attr['Apparelo Colour'][0]
 						doc=frappe.get_doc("Item",variant)
 						doc.print_code=new_variant
 						doc.save()

--- a/apparelo/apparelo/doctype/steaming/steaming.py
+++ b/apparelo/apparelo/doctype/steaming/steaming.py
@@ -10,7 +10,8 @@ from apparelo.apparelo.utils.utils import is_similar_bom
 from erpnext import get_default_company, get_default_currency
 from erpnext.controllers.item_variant import generate_keyed_value_combinations, get_variant
 from apparelo.apparelo.utils.item_utils import get_attr_dict, get_item_attribute_set, create_variants
-import hashlib
+from apparelo.apparelo.common_scripts import customize_pf_item_code
+
 class Steaming(Document):
 	def on_submit(self):
 		create_item_template()
@@ -26,19 +27,7 @@ class Steaming(Document):
 		for variant in variants:
 			variant_doc=frappe.get_doc("Item",variant)
 			variant_attr = get_attr_dict(variant_doc.attributes)
-			for dia in attribute_set["Dia"]:
-				if dia in variant_attr['Dia']:
-					if not dia+" Dia" in variant:
-						hash_=hashlib.sha256(variant.replace('Steamed Cloth',"").encode()).hexdigest()
-						new_variant=variant.replace(dia,dia+" Dia")
-						doc=frappe.get_doc("Item",variant)
-						doc.print_code=new_variant
-						doc.save()
-						new_variant=new_variant+" "+hash_[0:7]
-						r_variant=frappe.rename_doc("Item",variant,new_variant)
-						new_variants.append(r_variant)
-					else:
-						new_variants.append(variant)
+			new_variants.append(customize_pf_item_code('Steamed Cloth', attribute_set, variant_attr, variant))
 		if len(new_variants)==0:
 			new_variants=variants
 		return new_variants, attribute_set

--- a/apparelo/apparelo/doctype/supplier_process/supplier_process.json
+++ b/apparelo/apparelo/doctype/supplier_process/supplier_process.json
@@ -10,16 +10,16 @@
  "fields": [
   {
    "fieldname": "processes",
-   "fieldtype": "Select",
+   "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Process",
-   "options": "\nKnitting\nDyeing\nBleaching\nCompacting\nSteaming\nCutting\nPiece Printing\nStitching\nLabel Fusing\nChecking\nIroning\nPacking\nRoll Printing\nIroning & Packing\nStitching to Packing\nYarn\nCutting to Packing\nWashing\nRework(Piece)\nTransfer",
+   "options": "Apparelo Process",
    "reqd": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2019-12-30 13:18:43.772101",
+ "modified": "2020-05-20 18:17:56.865767",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Supplier_Process",

--- a/apparelo/apparelo/patches/v1/address_custom_field.py
+++ b/apparelo/apparelo/patches/v1/address_custom_field.py
@@ -1,0 +1,7 @@
+
+from __future__ import unicode_literals
+
+
+def execute():
+	from apparelo.apparelo.common_scripts import set_custom_fields
+	set_custom_fields()

--- a/apparelo/patches.txt
+++ b/apparelo/patches.txt
@@ -12,3 +12,4 @@ apparelo.apparelo.patches.v1.create_item_group
 apparelo.apparelo.patches.v1.warehouse_custom_fields
 apparelo.apparelo.patches.v1.create_custom_fields
 apparelo.apparelo.patches.v1.warehouse_update
+apparelo.apparelo.patches.v1.address_custom_field


### PR DESCRIPTION
This PR resolves below priority issues,
- PF item code has too much info (in dyeing GRN)
- In GRN Error on receiving extra qty
- From address mentioning in DC
- Link process doctype in supplier
- Change yarn secondary quantity as bags
- Hide is_combined after part is created