### PR TITLE
The ipd submission error and helper sections are handled.

### DIFF
--- a/apparelo/apparelo/common_scripts.py
+++ b/apparelo/apparelo/common_scripts.py
@@ -34,3 +34,16 @@ def set_custom_fields(update=True):
 			]
 		}
 	create_custom_fields(custom_fields, ignore_validate=frappe.flags.in_patch, update=update)
+
+def se_custom_field(update=True):
+	custom_fields = {
+		'Stock Entry': [
+			{
+				"fieldname": "dc",
+				"fieldtype": "Link",
+				"label": "DC",
+				"options": "DC"
+			}
+		]
+		}
+	create_custom_fields(custom_fields, ignore_validate=frappe.flags.in_patch, update=update)

--- a/apparelo/apparelo/doctype/compacting/compacting.py
+++ b/apparelo/apparelo/doctype/compacting/compacting.py
@@ -22,7 +22,6 @@ class Compacting(Document):
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
 		attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes, input_items)))
-		attribute_set.update(self.get_variant_values())
 		variants = create_variants('Compacted Cloth', attribute_set)
 		for variant in variants:
 			variant_doc=frappe.get_doc("Item",variant)
@@ -44,7 +43,7 @@ class Compacting(Document):
 				variant_attr = get_attr_dict(variant_doc.attributes)
 				for color in attribute_set['Apparelo Colour']:
 					for dia in self.dia_conversions:
-						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.to_dia in variant_attr["Dia"]:
+						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
 							bom_for_variant = frappe.get_doc({
 								"doctype": "BOM",
 								"currency": get_default_currency(),
@@ -74,14 +73,6 @@ class Compacting(Document):
 								else:
 									frappe.throw(_("Active BOM with different Materials or qty already exists for the item {0}. Please make these BOMs inactive and try again.").format(variant))
 		return boms
-
-	def get_variant_values(self):
-		attribute_set = {}
-		variant_to_dia = []
-		for to_dia in self.dia_conversions:
-			variant_to_dia.append(to_dia.to_dia)
-		attribute_set['Dia']=variant_to_dia
-		return attribute_set
 
 def create_item_template():
 	if not frappe.db.exists("Item","Compacted Cloth"):

--- a/apparelo/apparelo/doctype/dc/dc.py
+++ b/apparelo/apparelo/doctype/dc/dc.py
@@ -49,6 +49,7 @@ class DC(Document):
 			rm_items.append(item_list)
 		stock_dict = make_rm_stock_entry(new_po.name, json.dumps(rm_items))
 		stock_entry = frappe.get_doc(stock_dict)
+		stock_entry.dc = self.name
 		stock_entry.save()
 		stock_entry.submit()
 
@@ -57,6 +58,10 @@ class DC(Document):
 		msgprint(_("{0} created").format(comma_and(
 			"""<a href="#Form/Stock Entry/{0}">{1}</a>""".format(stock_entry.name, stock_entry.name))))
 
+	def on_cancel(self):
+		self.db_set("docstatus",2)
+		msgprint(_("{0} cancelled").format(comma_and("""<a href="#Form/DC/{0}">{1}</a>""".format(self.name, self.name))))
+		
 	def create_purchase_order(self):
 		dc_items = []
 		lot_warehouse = frappe.db.get_value("Warehouse", {

--- a/apparelo/apparelo/doctype/grn/grn.py
+++ b/apparelo/apparelo/doctype/grn/grn.py
@@ -12,11 +12,15 @@ from frappe.utils import cstr, flt, cint, nowdate, add_days, comma_and, now_date
 
 class GRN(Document):
 	def validate(self):
-		self.po=None
 		self.get_po()
 	def on_submit(self):
 		pr=self.create_purchase_receipt()
 		msgprint(_("{0} created").format(comma_and("""<a href="#Form/Purchase Receipt/{0}">{1}</a>""".format(pr.name, pr.name))))
+	
+	def on_cancel(self):
+		self.db_set("docstatus",2)
+		msgprint(_("{0} cancelled").format(comma_and("""<a href="#Form/GRN/{0}">{1}</a>""".format(self.name, self.name))))
+	
 	def create_purchase_receipt(self):
 		item_list=[]
 		lot_warehouse= frappe.db.get_value("Warehouse", {'location': self.location,'lot': self.lot,'warehouse_type':'Actual'},'name')
@@ -31,6 +35,7 @@ class GRN(Document):
 			"is_subcontracted": po_doc.is_subcontracted,
 			"supplier_warehouse": po_doc.supplier_warehouse,
 			"doctype": "Purchase Receipt",
+			"grn": self.name,
 			"items": item_list })
 		pr.save()
 		pr.submit()

--- a/apparelo/apparelo/doctype/item_production_detail/item_production_detail.py
+++ b/apparelo/apparelo/doctype/item_production_detail/item_production_detail.py
@@ -16,7 +16,6 @@ from frappe.utils.background_jobs import enqueue
 
 class ItemProductionDetail(Document):
 	def on_submit(self):
-		self.create_item_templates()
 		if self.ipd_submission_done:
 			return
 		self.validate_process_records()
@@ -636,6 +635,7 @@ def get_existing_process_variants(process_variants,ipd,process,cutting_attribute
 def submit_ipd(ipd):
 	try:
 		ipd_doc = frappe.get_doc("Item Production Detail", ipd)
+		item_templates=ipd_doc.create_item_templates()
 		ipd_list=ipd_doc.create_process_details()
 		ipd_item_mapping(ipd_list,ipd_doc.name,ipd_doc.item)
 		ipd_bom_mapping(ipd_list,ipd_doc.name,ipd_doc.item)

--- a/apparelo/apparelo/doctype/steaming/steaming.py
+++ b/apparelo/apparelo/doctype/steaming/steaming.py
@@ -22,7 +22,6 @@ class Steaming(Document):
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
 		attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes, input_items)))
-		attribute_set.update(self.get_variant_values())
 		variants = create_variants('Steamed Cloth', attribute_set)
 		for variant in variants:
 			variant_doc=frappe.get_doc("Item",variant)
@@ -44,7 +43,7 @@ class Steaming(Document):
 				variant_attr = get_attr_dict(variant_doc.attributes)
 				for color in attribute_set['Apparelo Colour']:
 					for dia in self.dia_conversions:
-						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.to_dia in variant_attr["Dia"]:
+						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
 							bom_for_variant = frappe.get_doc({
 								"doctype": "BOM",
 								"currency": get_default_currency(),
@@ -74,15 +73,6 @@ class Steaming(Document):
 								else:
 									frappe.throw(_("Active BOM with different Materials or qty already exists for the item {0}. Please make these BOMs inactive and try again.").format(variant))
 		return boms
-
-	def get_variant_values(self):
-		attribute_set = {}
-		variant_to_dia = []
-		for to_dia in self.dia_conversions:
-			variant_to_dia.append(to_dia.to_dia)
-		attribute_set['Dia']=variant_to_dia
-		return attribute_set
-
 
 def create_item_template():
 	if not frappe.db.exists("Item","Steamed Cloth"):

--- a/apparelo/apparelo/patches/v1/se_custom_field.py
+++ b/apparelo/apparelo/patches/v1/se_custom_field.py
@@ -1,0 +1,7 @@
+
+from __future__ import unicode_literals
+
+
+def execute():
+	from apparelo.apparelo.common_scripts import se_custom_field
+	se_custom_field()

--- a/apparelo/apparelo/utils/item_utils.py
+++ b/apparelo/apparelo/utils/item_utils.py
@@ -8,6 +8,7 @@ from frappe.model.document import Document
 from frappe.core.doctype.version.version import get_diff
 from erpnext.controllers.item_variant import generate_keyed_value_combinations, get_variant, create_variant
 
+stock_settings_doc = frappe.get_doc("Stock Settings")
 def create_variants(item_template, args):
 	args_set = generate_keyed_value_combinations(args)
 	variants = []
@@ -15,6 +16,7 @@ def create_variants(item_template, args):
 		existing_variant = get_variant(item_template, args=attribute_values)
 		if not existing_variant:
 			variant = create_variant(item_template, attribute_values)
+			variant.over_delivery_receipt_allowance = stock_settings_doc.over_delivery_receipt_allowance
 			variant.save()
 			variants.append(variant.name)
 		else:

--- a/apparelo/patches.txt
+++ b/apparelo/patches.txt
@@ -13,3 +13,4 @@ apparelo.apparelo.patches.v1.warehouse_custom_fields
 apparelo.apparelo.patches.v1.create_custom_fields
 apparelo.apparelo.patches.v1.warehouse_update
 apparelo.apparelo.patches.v1.address_custom_field
+apparelo.apparelo.patches.v1.se_custom_field


### PR DESCRIPTION
This PR resolves below issues,
- [X] Error in item template creation on submission of ipd.
- [X] Receive in excess has to be set for all items.
- [X] Knitting Dia will be carried from first to the last step. Compacting Dia is just a point of information. But will not be used in change of name or item attribute. This is because Compacting Dia will keep changing. A roll can be sent back to compacting to modify dia multiple times. 
- [X] What to do about cancelling the DC and GRN?

![Screenshot from 2020-05-27 17-22-33](https://user-images.githubusercontent.com/36359901/83096758-200d5400-a0c4-11ea-87f7-1e529ccc01e4.png)

![Screenshot from 2020-05-27 19-10-32](https://user-images.githubusercontent.com/36359901/83096657-db81b880-a0c3-11ea-9173-ad1e7db26a15.png)
