### PR TITLE
Set permissions for the created roles to access apparelo related doctypes

### DIFF
--- a/apparelo/apparelo/doctype/additional_parameters/additional_parameters.json
+++ b/apparelo/apparelo/doctype/additional_parameters/additional_parameters.json
@@ -25,7 +25,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-27 12:05:08.453136",
+ "modified": "2020-07-09 15:12:11.378945",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Additional Parameters",
@@ -40,6 +40,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_colour/apparelo_colour.json
+++ b/apparelo/apparelo/doctype/apparelo_colour/apparelo_colour.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-09 15:26:56.578561",
+ "modified": "2020-07-09 15:12:13.029774",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Colour",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_dia/apparelo_dia.json
+++ b/apparelo/apparelo/doctype/apparelo_dia/apparelo_dia.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-25 16:49:07.229884",
+ "modified": "2020-07-09 15:12:12.240610",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Dia",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_part/apparelo_part.json
+++ b/apparelo/apparelo/doctype/apparelo_part/apparelo_part.json
@@ -50,7 +50,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-20 19:11:13.596420",
+ "modified": "2020-07-09 15:12:12.710075",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Part",
@@ -65,6 +65,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_process/apparelo_process.json
+++ b/apparelo/apparelo/doctype/apparelo_process/apparelo_process.json
@@ -38,7 +38,7 @@
   }
  ],
  "links": [],
- "modified": "2020-02-12 21:37:38.200559",
+ "modified": "2020-07-09 15:12:13.337225",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Process",
@@ -53,6 +53,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_settings/apparelo_settings.json
+++ b/apparelo/apparelo/doctype/apparelo_settings/apparelo_settings.json
@@ -18,7 +18,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2020-02-26 15:18:32.804396",
+ "modified": "2020-07-09 15:12:13.653551",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Settings",
@@ -31,6 +31,16 @@
    "print": 1,
    "read": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_size/apparelo_size.json
+++ b/apparelo/apparelo/doctype/apparelo_size/apparelo_size.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-09 15:26:32.536145",
+ "modified": "2020-07-09 15:12:11.693898",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Size",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_style/apparelo_style.json
+++ b/apparelo/apparelo/doctype/apparelo_style/apparelo_style.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-22 13:17:52.546202",
+ "modified": "2020-07-09 15:12:11.925851",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Style",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/apparelo_yarn_shade/apparelo_yarn_shade.json
+++ b/apparelo/apparelo/doctype/apparelo_yarn_shade/apparelo_yarn_shade.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-07-03 15:29:36.871912",
+ "modified": "2020-07-09 15:12:13.888705",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Yarn Shade",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/bleaching/bleaching.json
+++ b/apparelo/apparelo/doctype/bleaching/bleaching.json
@@ -136,7 +136,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-03 18:58:18.919847",
+ "modified": "2020-07-09 15:12:15.109487",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Bleaching",
@@ -152,6 +152,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/checking/checking.json
+++ b/apparelo/apparelo/doctype/checking/checking.json
@@ -29,7 +29,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-22 13:34:15.518779",
+ "modified": "2020-07-09 15:12:15.515711",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Checking",
@@ -45,6 +45,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/compacting/compacting.json
+++ b/apparelo/apparelo/doctype/compacting/compacting.json
@@ -80,7 +80,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-02-21 15:04:18.537665",
+ "modified": "2020-07-09 15:12:15.778939",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Compacting",
@@ -96,6 +96,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/cutting/cutting.json
+++ b/apparelo/apparelo/doctype/cutting/cutting.json
@@ -31,123 +31,91 @@
    "fieldtype": "Table",
    "label": "Details",
    "options": "Cutting Detail",
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "fieldname": "colour_mapping",
    "fieldtype": "Table",
    "label": "Colour Mapping",
    "options": "Cutting colour details",
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "fieldname": "column_break_4",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "collapsible": 1,
    "collapsible_depends_on": "eval: doc.__islocal",
    "depends_on": "eval: doc.docstatus == 0",
    "fieldname": "section_break_3",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "section_break_7",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "parts",
    "fieldtype": "Table MultiSelect",
    "label": "Parts",
-   "options": "Cutting Part",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Cutting Part"
   },
   {
    "fieldname": "sizes",
    "fieldtype": "Table MultiSelect",
    "label": "Sizes",
-   "options": "Cutting Size",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Cutting Size"
   },
   {
    "fieldname": "get_size_combination",
    "fieldtype": "Button",
-   "label": "Get size combination",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Get size combination"
   },
   {
    "collapsible": 1,
    "collapsible_depends_on": "eval: doc.__islocal",
    "depends_on": "eval: doc.docstatus == 0",
    "fieldname": "section_break_9",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "colours",
    "fieldtype": "Table MultiSelect",
    "label": "Colours",
-   "options": "Cutting Colors",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Cutting Colors"
   },
   {
    "fieldname": "get_colour_combination",
    "fieldtype": "Button",
-   "label": "Get colour combination",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Get colour combination"
   },
   {
    "fieldname": "section_break_12",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "colour_parts",
    "fieldtype": "Table MultiSelect",
    "label": "Parts",
-   "options": "Cutting Part",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Cutting Part"
   },
   {
    "fieldname": "column_break_12",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "default": "0",
    "fieldname": "based_on_style",
    "fieldtype": "Check",
-   "label": "Based on style",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Based on style"
   },
   {
    "depends_on": "based_on_style",
    "fieldname": "styles",
    "fieldtype": "Table MultiSelect",
    "label": "Styles",
-   "options": "Cutting Styles",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Cutting Styles"
   },
   {
    "fieldname": "amended_from",
@@ -156,23 +124,19 @@
    "no_copy": 1,
    "options": "Cutting",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
    "fieldname": "additional_information",
    "fieldtype": "Table",
    "label": "Additional Information",
-   "options": "Additional Information Table",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Additional Information Table"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-06-13 23:24:38.498884",
+ "modified": "2020-07-09 15:12:16.129674",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Cutting",
@@ -188,6 +152,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/dc/dc.json
+++ b/apparelo/apparelo/doctype/dc/dc.json
@@ -219,47 +219,35 @@
    "collapsible": 1,
    "fieldname": "helper_section",
    "fieldtype": "Section Break",
-   "label": "Helper Section",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Helper Section"
   },
   {
    "fieldname": "select_helper",
    "fieldtype": "Select",
-   "label": "Select Helper",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Select Helper"
   },
   {
    "depends_on": "eval:doc.process_1==\"Cutting\"",
    "fieldname": "section_break_18",
    "fieldtype": "Section Break",
-   "label": "Cutting Section",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Cutting Section"
   },
   {
    "fieldname": "colour",
    "fieldtype": "Link",
    "label": "Colour",
-   "options": "Apparelo Colour",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Apparelo Colour"
   },
   {
    "fieldname": "size",
    "fieldtype": "Link",
    "label": "Size",
-   "options": "Apparelo Size",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Apparelo Size"
   },
   {
    "fieldname": "piece_count",
    "fieldtype": "Float",
-   "label": "Piece Count",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Piece Count"
   },
   {
    "fieldname": "copy_over",
@@ -269,14 +257,12 @@
   {
    "fieldname": "make_entry",
    "fieldtype": "Button",
-   "label": "Make Entry",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Make Entry"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-06-01 20:43:48.162172",
+ "modified": "2020-07-09 15:12:16.548368",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "DC",
@@ -292,6 +278,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/dc/dc.json
+++ b/apparelo/apparelo/doctype/dc/dc.json
@@ -262,7 +262,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-09 15:12:16.548368",
+ "modified": "2020-07-09 15:31:31.499369",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "DC",
@@ -293,6 +293,29 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Data Entry Operator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Report Analyst",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/apparelo/apparelo/doctype/dyeing/dyeing.json
+++ b/apparelo/apparelo/doctype/dyeing/dyeing.json
@@ -132,7 +132,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-03 18:51:15.891368",
+ "modified": "2020-07-09 15:12:17.283436",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Dyeing",
@@ -148,6 +148,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/grn/grn.json
+++ b/apparelo/apparelo/doctype/grn/grn.json
@@ -187,7 +187,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-09 15:12:17.771143",
+ "modified": "2020-07-09 15:31:32.229517",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "GRN",
@@ -218,6 +218,29 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Data Entry Operator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Report Analyst",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/apparelo/apparelo/doctype/grn/grn.json
+++ b/apparelo/apparelo/doctype/grn/grn.json
@@ -187,7 +187,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-07 13:12:16.634172",
+ "modified": "2020-07-09 15:12:17.771143",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "GRN",
@@ -203,6 +203,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/ironing/ironing.json
+++ b/apparelo/apparelo/doctype/ironing/ironing.json
@@ -168,7 +168,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-22 13:35:26.718131",
+ "modified": "2020-07-09 15:12:18.266456",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Ironing",
@@ -184,6 +184,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/item_production_detail/item_production_detail.json
+++ b/apparelo/apparelo/doctype/item_production_detail/item_production_detail.json
@@ -137,7 +137,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-21 23:29:13.790075",
+ "modified": "2020-07-09 15:12:18.658297",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Item Production Detail",
@@ -153,6 +153,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/knitting/knitting.json
+++ b/apparelo/apparelo/doctype/knitting/knitting.json
@@ -95,7 +95,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-02-21 15:04:18.537665",
+ "modified": "2020-07-09 15:12:19.076144",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Knitting",
@@ -111,6 +111,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/knitting_type/knitting_type.json
+++ b/apparelo/apparelo/doctype/knitting_type/knitting_type.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-09 15:28:18.345765",
+ "modified": "2020-07-09 15:12:14.213651",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Knitting Type",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/label_fusing/label_fusing.json
+++ b/apparelo/apparelo/doctype/label_fusing/label_fusing.json
@@ -177,7 +177,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-22 13:30:58.060296",
+ "modified": "2020-07-09 15:12:19.418307",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Label Fusing",
@@ -193,6 +193,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/lot_closure/lot_closure.json
+++ b/apparelo/apparelo/doctype/lot_closure/lot_closure.json
@@ -109,7 +109,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-09 15:12:19.785130",
+ "modified": "2020-07-09 15:31:32.802598",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Lot Closure",
@@ -152,6 +152,29 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Data Entry Operator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Report Analyst",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/apparelo/apparelo/doctype/lot_closure/lot_closure.json
+++ b/apparelo/apparelo/doctype/lot_closure/lot_closure.json
@@ -109,7 +109,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-12 22:07:59.270041",
+ "modified": "2020-07-09 15:12:19.785130",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Lot Closure",
@@ -137,6 +137,20 @@
    "report": 1,
    "role": "Administrator",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/lot_creation/lot_creation.json
+++ b/apparelo/apparelo/doctype/lot_creation/lot_creation.json
@@ -141,7 +141,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-18 15:08:50.313323",
+ "modified": "2020-07-09 15:12:20.199447",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Lot Creation",
@@ -157,6 +157,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/multi_process/multi_process.json
+++ b/apparelo/apparelo/doctype/multi_process/multi_process.json
@@ -24,7 +24,7 @@
   }
  ],
  "links": [],
- "modified": "2020-02-11 12:38:28.827020",
+ "modified": "2020-07-09 15:12:14.523853",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Multi Process",
@@ -39,6 +39,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/packing/packing.json
+++ b/apparelo/apparelo/doctype/packing/packing.json
@@ -216,7 +216,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-22 13:36:05.192834",
+ "modified": "2020-07-09 15:12:20.663693",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Packing",
@@ -232,6 +232,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/piece_printing/piece_printing.json
+++ b/apparelo/apparelo/doctype/piece_printing/piece_printing.json
@@ -38,7 +38,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-04 12:11:46.059318",
+ "modified": "2020-07-09 15:12:21.042713",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Piece Printing",
@@ -54,6 +54,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/print_type/print_type.json
+++ b/apparelo/apparelo/doctype/print_type/print_type.json
@@ -26,7 +26,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-21 12:25:28.002718",
+ "modified": "2020-07-09 15:12:14.813660",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Print Type",
@@ -41,6 +41,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
    "share": 1,
    "write": 1
   }

--- a/apparelo/apparelo/doctype/roll_printing/roll_printing.json
+++ b/apparelo/apparelo/doctype/roll_printing/roll_printing.json
@@ -32,11 +32,11 @@
    "fieldtype": "Table",
    "label": "Additional Information",
    "options": "Additional Information Table"
-   }
+  }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-02-21 15:04:18.537665",
+ "modified": "2020-07-09 15:12:21.273407",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Roll Printing",
@@ -52,6 +52,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/steaming/steaming.json
+++ b/apparelo/apparelo/doctype/steaming/steaming.json
@@ -88,7 +88,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-02-21 15:04:18.537665",
+ "modified": "2020-07-09 15:12:21.546273",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Steaming",
@@ -104,6 +104,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/apparelo/apparelo/doctype/stitching/stitching.json
+++ b/apparelo/apparelo/doctype/stitching/stitching.json
@@ -229,7 +229,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-22 13:33:24.634622",
+ "modified": "2020-07-09 15:12:21.855060",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Stitching",
@@ -245,6 +245,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
This PR helps to assign permissions to the apparelo doctypes.           
1.  Apparelo Admin : ```'Additional Parameters', 'Apparelo Size', 'Apparelo Style', 'Apparelo Dia', 'Apparelo Part', 'Apparelo Colour', 'Apparelo Process', 'Apparelo Settings', 'Apparelo Yarn Shade', 'Knitting Type', 'Multi Process', 'Print Type','Bleaching', 'Checking', 'Compacting', 'Cutting', 'DC', 'Dyeing', 'GRN', 'Ironing', 'Item Production Detail', 'Knitting','Label Fusing', 'Lot Closure', 'Lot Creation', 'Packing', 'Piece Printing', 'Roll Printing', 'Steaming', 'Stitching'```

2.  Data Entry Operator and Report Analyst: ```'DC','GRN', 'Lot Closure'```
    