### PR TITLE
Core doctype permissions

### DIFF
--- a/apparelo/apparelo/common_scripts.py
+++ b/apparelo/apparelo/common_scripts.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import hashlib
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.permissions import add_permission, update_permission_property
 
 def customize_pf_item_code(item_template, attribute_set, variant_attr, variant):
 	for dia in attribute_set["Dia"]:
@@ -54,3 +55,36 @@ def create_default_roles():
 			role_doc = frappe.new_doc("Role")
 			role_doc.role_name = role
 			role_doc.save()
+
+def set_permissions_to_core_doctypes():
+	roles = ['Apparelo Admin', 'Apparelo Data Entry Operator']
+	admin_all_permission = ['Item', 'Purchase Order', 'Stock Entry']
+	common_read_permission = ['Item Attribute', 'Item Group', 'Warehouse', 'Location', 'Supplier', 'Address', 'Company']
+	read_permission_dict = {'Apparelo Admin': ['BOM', 'UOM', 'DocType', 'Material Request', 'Stock Entry Type'], 'Apparelo Data Entry Operator': ['Account', 'Item', 'Purchase Order']}
+	
+	# assign journal entry create permission to data entry operator.
+	add_permission('Journal Entry', 'Apparelo Data Entry Operator', 0)
+	update_permission_property('Journal Entry', 'Apparelo Data Entry Operator', 0, 'create', 1)
+	
+	# assign read permission to the corresponding doctype.
+	for role in read_permission_dict.keys():
+		for doc in read_permission_dict[role]:
+			add_permission(doc, role, 0)
+			update_permission_property(doc, role, 0, 'read', 1)
+	
+	# assign common read permission to both roles.
+	for role in roles:
+		for doc in common_read_permission:
+			add_permission(doc, role, 0)
+			update_permission_property(doc, role, 0, 'read', 1)
+
+	# assign all permission to apparelo admin.
+	for doc in admin_all_permission:
+		add_permission(doc, 'Apparelo Admin', 0)
+		if doc != 'Item':
+			update_permission_property(doc, 'Apparelo Admin', 0, 'submit', 1)
+			update_permission_property(doc, 'Apparelo Admin', 0, 'cancel', 1)
+		update_permission_property(doc, 'Apparelo Admin', 0, 'read', 1)
+		update_permission_property(doc, 'Apparelo Admin', 0, 'create', 1)
+		update_permission_property(doc, 'Apparelo Admin', 0, 'delete', 1)
+		update_permission_property(doc, 'Apparelo Admin', 0, 'write', 1)

--- a/apparelo/apparelo/doctype/apparelo_process/apparelo_process.json
+++ b/apparelo/apparelo/doctype/apparelo_process/apparelo_process.json
@@ -38,7 +38,7 @@
   }
  ],
  "links": [],
- "modified": "2020-02-12 21:37:38.200559",
+ "modified": "2020-07-11 14:31:14.542563",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Apparelo Process",
@@ -55,6 +55,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Data Entry Operator",
+   "share": 1
   }
  ],
  "quick_entry": 1,

--- a/apparelo/apparelo/doctype/ipd_bom_mapping/ipd_bom_mapping.json
+++ b/apparelo/apparelo/doctype/ipd_bom_mapping/ipd_bom_mapping.json
@@ -35,7 +35,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-06 11:51:04.149006",
+ "modified": "2020-07-11 14:31:58.576364",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "IPD BOM Mapping",
@@ -52,6 +52,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1
   }
  ],
  "quick_entry": 1,

--- a/apparelo/apparelo/doctype/ipd_item_mapping/ipd_item_mapping.json
+++ b/apparelo/apparelo/doctype/ipd_item_mapping/ipd_item_mapping.json
@@ -35,7 +35,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-06 11:51:22.625056",
+ "modified": "2020-07-11 14:32:25.147457",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "IPD Item Mapping",
@@ -52,6 +52,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Admin",
+   "share": 1
   }
  ],
  "quick_entry": 1,

--- a/apparelo/apparelo/doctype/lot_creation/lot_creation.json
+++ b/apparelo/apparelo/doctype/lot_creation/lot_creation.json
@@ -141,7 +141,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-18 15:08:50.313323",
+ "modified": "2020-07-11 14:30:08.121216",
  "modified_by": "Administrator",
  "module": "Apparelo",
  "name": "Lot Creation",
@@ -158,6 +158,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Apparelo Data Entry Operator",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/apparelo/apparelo/patches/v1/set_default_permissions.py
+++ b/apparelo/apparelo/patches/v1/set_default_permissions.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+
+def execute():
+    from apparelo.apparelo.common_scripts import set_permissions_to_core_doctypes
+    set_permissions_to_core_doctypes()

--- a/apparelo/install.py
+++ b/apparelo/install.py
@@ -21,7 +21,7 @@ from apparelo.apparelo.doctype.grn.warehouse_custom_fields import make_warehouse
 from apparelo.apparelo.doctype.lot_creation.custom_scripts import set_custom_fields
 from apparelo.apparelo.common_scripts import set_address_custom_fields
 from apparelo.apparelo.doctype.lot_creation.custom_scripts import change_stores_warehouse
-from apparelo.apparelo.common_scripts import create_default_roles
+from apparelo.apparelo.common_scripts import create_default_roles, set_permissions_to_core_doctypes
 
 
 def after_install():
@@ -42,6 +42,7 @@ def after_install():
     set_address_custom_fields()
     change_stores_warehouse()
     create_default_roles()
+    set_permissions_to_core_doctypes()
 
 
 def create_item_attributes():

--- a/apparelo/patches.txt
+++ b/apparelo/patches.txt
@@ -16,3 +16,4 @@ apparelo.apparelo.patches.v1.se_custom_field
 apparelo.apparelo.patches.v1.create_apparelo_yarn_shade
 apparelo.apparelo.patches.v1.custom_field_address
 apparelo.apparelo.patches.v1.create_default_roles
+apparelo.apparelo.patches.v1.set_default_permissions


### PR DESCRIPTION
This PR helps to assign permissions for core doctypes.
1. Read permission - 
      #Apparelo Admin - 'BOM', 'UOM', 'DocType', 'Material Request', 'Stock Entry Type'
      #Data Entry -  'Account', 'Item', 'Purchase Order'
2. Common Read permissions - 'Item Attribute', 'Item Group', 'Warehouse', 'Location', 'Supplier', 'Address', 'Company'
3. All permission - 'Item', 'Purchase Order', 'Stock Entry'(Apparelo Admin)