### PR TITLE
Fix: Full flow issues

### DIFF
--- a/apparelo/apparelo/doctype/compacting/compacting.py
+++ b/apparelo/apparelo/doctype/compacting/compacting.py
@@ -45,7 +45,9 @@ class Compacting(Document):
 				variant_attr = get_attr_dict(variant_doc.attributes)
 				for color in apparelo_colours:
 					for dia in self.dia_conversions:
-						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
+						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] \
+							and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"] \
+							and input_attr['Knitting Type'] == variant_attr['Knitting Type']:
 							bom_for_variant = frappe.get_doc({
 								"doctype": "BOM",
 								"currency": get_default_currency(),

--- a/apparelo/apparelo/doctype/compacting/compacting.py
+++ b/apparelo/apparelo/doctype/compacting/compacting.py
@@ -19,19 +19,21 @@ class Compacting(Document):
 	def create_variants(self, input_item_names):
 		new_variants=[]
 		input_items = []
+		apparelo_colours = []
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
-		attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes, input_items)))
-		variants = create_variants('Compacted Cloth', attribute_set)
-		for variant in variants:
-			variant_doc=frappe.get_doc("Item",variant)
+		for item in input_items:
+			attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes,[item])))
+			apparelo_colours.extend(attribute_set['Apparelo Colour'])
+			variant = create_variants('Compacted Cloth', attribute_set)
+			variant_doc=frappe.get_doc("Item",variant[0])
 			variant_attr = get_attr_dict(variant_doc.attributes)
-			new_variants.append(customize_pf_item_code('Compacted Cloth', attribute_set, variant_attr, variant))
+			new_variants.append(customize_pf_item_code('Compacted Cloth', attribute_set, variant_attr, variant[0]))
 		if len(new_variants)==0:
 			new_variants=variants
-		return new_variants, attribute_set
+		return new_variants, set(apparelo_colours)
 
-	def create_boms(self, input_item_names, variants, attribute_set,item_size,colour,piece_count):
+	def create_boms(self, input_item_names, variants, apparelo_colours,item_size,colour,piece_count):
 		input_items = []
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
@@ -41,7 +43,7 @@ class Compacting(Document):
 			for variant in variants:
 				variant_doc=frappe.get_doc("Item",variant)
 				variant_attr = get_attr_dict(variant_doc.attributes)
-				for color in attribute_set['Apparelo Colour']:
+				for color in apparelo_colours:
 					for dia in self.dia_conversions:
 						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
 							bom_for_variant = frappe.get_doc({

--- a/apparelo/apparelo/doctype/cutting/cutting.py
+++ b/apparelo/apparelo/doctype/cutting/cutting.py
@@ -175,7 +175,7 @@ def get_part_size_combination(doc):
 	for size in doc.get('sizes'):
 		for part in doc.get('parts'):
 			part_size_combination.append({'part':part['parts'],'size':size['size']})
-	return map(dict, set(tuple(value.items()) for value in part_size_combination))
+	return map(dict, sorted(set(tuple(value.items()) for value in part_size_combination)))
 
 
 @frappe.whitelist()
@@ -200,7 +200,7 @@ def get_part_colour_combination(doc):
 			for part in doc.get('colour_parts'):
 				for style in doc.get('styles'):
 					part_colour_combination.append({'part':part['parts'],'colour':colour['colors'],'style':style['styles']})
-	return map(dict, set(tuple(value.items()) for value in part_colour_combination))
+	return map(dict, sorted(set(tuple(value.items()) for value in part_colour_combination)))
 
 def create_common_bom(self, variant,attr, input_items, process_record, idx):
 	dia_weight,count=self.get_matching_details(attr["Part"], attr["Apparelo Size"])
@@ -231,7 +231,9 @@ def create_common_bom(self, variant,attr, input_items, process_record, idx):
 					return bom.name
 				else:
 					return existing_bom
-	frappe.throw(_(f'Colour {attr["Apparelo Colour"][0]} or Dia {attr["Dia"]} entered in cutting process record {process_record} at row {idx} was not found in the input item list'))
+	dia = attr["Dia"]
+	apparelo_colour = attr["Apparelo Colour"][0]
+	frappe.throw(_(f'Colour {apparelo_colour} or Dia {dia} entered in cutting process record {process_record} at row {idx} was not found in the input item list'))
 
 def is_combined_parts(item):
 	item_doc=frappe.get_doc("Item",item)

--- a/apparelo/apparelo/doctype/cutting/cutting.py
+++ b/apparelo/apparelo/doctype/cutting/cutting.py
@@ -175,7 +175,7 @@ def get_part_size_combination(doc):
 	for size in doc.get('sizes'):
 		for part in doc.get('parts'):
 			part_size_combination.append({'part':part['parts'],'size':size['size']})
-	return part_size_combination
+	return map(dict, set(tuple(value.items()) for value in part_size_combination))
 
 
 @frappe.whitelist()
@@ -200,7 +200,7 @@ def get_part_colour_combination(doc):
 			for part in doc.get('colour_parts'):
 				for style in doc.get('styles'):
 					part_colour_combination.append({'part':part['parts'],'colour':colour['colors'],'style':style['styles']})
-	return(part_colour_combination)
+	return map(dict, set(tuple(value.items()) for value in part_colour_combination))
 
 def create_common_bom(self, variant,attr, input_items, process_record, idx):
 	dia_weight,count=self.get_matching_details(attr["Part"], attr["Apparelo Size"])

--- a/apparelo/apparelo/doctype/dc/dc.js
+++ b/apparelo/apparelo/doctype/dc/dc.js
@@ -2,6 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('DC', {
+	refresh: function(frm) {
+		if (frm.doc.docstatus === 1 && frm.doc.return_materials) {
+			frm.add_custom_button(__("GRN"), ()=> {
+				frm.trigger("make_grn");
+			}, __('Create'));
+		}
+		frm.page.set_inner_btn_group_as_primary(__('Create'));
+	},
+	make_grn: function() {
+		frappe.model.open_mapped_doc({
+			method: "apparelo.apparelo.doctype.dc.dc.make_grn",
+			frm: cur_frm,
+			freeze_message: __("Creating GRN ...")
+		})
+	},
 	onload: function(frm) {
 		frm.set_value("company",frappe.defaults.get_default("company"));
 		frappe.db.get_list("Address",{filters:{is_shipping_address: 1}}).then(data => {

--- a/apparelo/apparelo/doctype/dc/dc.py
+++ b/apparelo/apparelo/doctype/dc/dc.py
@@ -7,6 +7,7 @@ import frappe
 import json
 import math
 from frappe import _, msgprint
+from frappe.model.mapper import get_mapped_doc
 from six import string_types, iteritems
 from frappe.model.document import Document
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
@@ -749,3 +750,20 @@ def make_entry(doc):
 					item_dict["additional_parameters"] = item['additional_parameters']
 				return_items_after_entry.append(item_dict)
 	return return_items_after_entry
+
+@frappe.whitelist()
+def make_grn(source_name, target_doc=None):
+	doc = get_mapped_doc("DC", source_name,	{
+		"DC": {
+			"doctype": "GRN",
+			"field_map": {
+				"supplier": "supplier",
+				"lot": "lot",
+				"expect_return_items_at": "location",
+				"name": "against_document",
+				"doctype": "against_type",
+				"return_materials": "return_materials"
+			}
+			}
+		}, target_doc)
+	return doc

--- a/apparelo/apparelo/doctype/dyeing/dyeing.py
+++ b/apparelo/apparelo/doctype/dyeing/dyeing.py
@@ -155,4 +155,4 @@ def get_colour_shade_comibination(doc):
 	for colour in colours:
 		colour_shade_mapping.append({'yarn_shade': doc.get('yarn_shade'),'colour': colour['colour']})
 	
-	return map(dict, set(tuple(value.items()) for value in colour_shade_mapping))
+	return map(dict, sorted(set(tuple(value.items()) for value in colour_shade_mapping)))

--- a/apparelo/apparelo/doctype/grn/grn.py
+++ b/apparelo/apparelo/doctype/grn/grn.py
@@ -71,6 +71,7 @@ class GRN(Document):
 			process = frappe.db.get_value('DC',{'name': self.against_document},'process_1')
 			return get_grouping_params(process)
 
+@frappe.whitelist()
 def get_type(doctype, txt, searchfield, start, page_len, filters):
 	if filters['type']=='DC':
 		DC = [[dc['name']] for dc in frappe.get_list("DC", filters={'supplier': ['in',filters['supplier']],'lot':['in',filters['lot']]}, fields=["name"])]
@@ -78,12 +79,16 @@ def get_type(doctype, txt, searchfield, start, page_len, filters):
 	else:
 		PO = [[po['name']] for po in frappe.get_list("Purchase Order", filters={'supplier': ['in',filters['supplier']],'lot':['in',filters['lot']]}, fields=["name"])]
 		return PO
+
+@frappe.whitelist()
 def get_Lot(doctype, txt, searchfield, start, page_len, filters):
 	lot_list = []
 	for lot in frappe.get_list("Purchase Order", fields=["lot"]):
 		if not lot['lot'] in lot_list:
 			lot_list.append([lot['lot']])
 	return lot_list
+
+@frappe.whitelist()
 def get_supplier(doctype, txt, searchfield, start, page_len, filters):
 	supplier_list = []
 	for supplier in frappe.get_list("Purchase Order", fields=["supplier"]):

--- a/apparelo/apparelo/doctype/grn/grn.py
+++ b/apparelo/apparelo/doctype/grn/grn.py
@@ -199,10 +199,10 @@ def duplicate_values(doc):
 	for item in doc.get('return_materials'):
 		field_dict = {'Received Qty':'received_qty','Rejected Qty':'rejected_qty','Expected Qty':'qty'}
 		if doc.from_field in field_dict and doc.to_field in field_dict:
-			if 'secondary_qty' in item:
+			if 'secondary_qty' in item and 'secondary_uom' in item:
 				item_dict = {"pf_item_code":item['pf_item_code'],"item_code":item['item_code'],field_dict[doc.from_field]:item[field_dict[doc.from_field]],field_dict[doc.to_field]:item[field_dict[doc.from_field]],"qty":item['qty'],"uom":item['uom'],"secondary_qty":item["secondary_qty"],"secondary_uom":item['secondary_uom']}
 			else:
-				item_dict = {"pf_item_code":item['pf_item_code'],"item_code":item['item_code'],field_dict[doc.from_field]:item[field_dict[doc.from_field]],field_dict[doc.to_field]:item[field_dict[doc.from_field]],"qty":item['qty'],"uom":item['uom'],"secondary_uom":item['secondary_uom']}	
+				item_dict = {"pf_item_code":item['pf_item_code'],"item_code":item['item_code'],field_dict[doc.from_field]:item[field_dict[doc.from_field]],field_dict[doc.to_field]:item[field_dict[doc.from_field]],"qty":item['qty'],"uom":item['uom']}	
 		field_dict.pop(doc.from_field)
 		field_dict.pop(doc.to_field)
 		if list(field_dict.values())[0] in item:

--- a/apparelo/apparelo/doctype/item_production_detail/item_production_detail.py
+++ b/apparelo/apparelo/doctype/item_production_detail/item_production_detail.py
@@ -21,6 +21,10 @@ class ItemProductionDetail(Document):
 		if self.ipd_submission_done:
 			self.ipd_submission_done = 0
 	def on_submit(self):
+		is_template = frappe.db.get_value('Item',self.item, 'has_variants')
+		if not is_template:
+			frappe.throw(_("Kindly make the final product item {0} as a template.").format(comma_and(
+			"""<a href="#Form/Item/{0}">{1}</a>""".format(self.item, self.item))))
 		if self.ipd_submission_done:
 			return
 		self.validate_process_records()
@@ -235,9 +239,9 @@ class ItemProductionDetail(Document):
 									input_items_.extend(input_items)
 									process_variants['process_record'] = process.process_record
 									steaming_doc = frappe.get_doc('Steaming', process.process_record)
-									variant,attribute_set = steaming_doc.create_variants(input_items)
+									variant,apparelo_colours = steaming_doc.create_variants(input_items)
 									variants.extend(variant)
-									boms.extend(steaming_doc.create_boms(input_items, variants, attribute_set,item_size,colour,piece_count))
+									boms.extend(steaming_doc.create_boms(input_items, variants, apparelo_colours,item_size,colour,piece_count))
 						process_variants['variants'] = list(set(variants))
 						process_variants['BOM']=list(set(boms))
 						process_variants['input_item']=list(set(input_items_))
@@ -264,9 +268,9 @@ class ItemProductionDetail(Document):
 									input_items_.extend(input_items)
 									process_variants['process_record'] = process.process_record
 									compacting_doc = frappe.get_doc('Compacting', process.process_record)
-									variant,attribute_set = compacting_doc.create_variants(input_items)
+									variant,apparelo_colours = compacting_doc.create_variants(input_items)
 									variants.extend(variant)
-									boms.extend(compacting_doc.create_boms(input_items, variants, attribute_set,item_size,colour,piece_count))
+									boms.extend(compacting_doc.create_boms(input_items, variants, apparelo_colours,item_size,colour,piece_count))
 						process_variants['variants'] = list(set(variants))
 						process_variants['BOM']=list(set(boms))
 						process_variants['input_item']=list(set(input_items_))

--- a/apparelo/apparelo/doctype/lot_creation/lot_creation.py
+++ b/apparelo/apparelo/doctype/lot_creation/lot_creation.py
@@ -228,7 +228,12 @@ def cloth_qty(doc):
 			for colth_colour in table:
 				knitted_colour.append(colth_colour.colour)
 				colour_list.add(colth_colour.colour)
-			yarn_list.append({'yarn': ipd_process.input_item, 'index': ipd_process.idx, 'dia': dia_list})
+			ipd_item_mapping_doc = frappe.get_doc('IPD Item Mapping',{'item_production_details':doc.item_production_detail})
+			out_item_list = []
+			for row in ipd_item_mapping_doc.item_mapping:
+				if str(ipd_process.idx) in row.input_index:
+					out_item_list.append(row.item)
+			yarn_list.append({'yarn': ipd_process.input_item, 'dia': dia_list, 'out_items': out_item_list})
 		elif ipd_process.process_name == 'Compacting' or ipd_process.process_name == 'Steaming':
 			process.append(ipd_process.process_name)
 	process = list(set(process))
@@ -262,16 +267,6 @@ def cloth_qty(doc):
 	for data in yarn_list:
 		html_body = ''
 		dia_qty_list =[]
-		combined_input_idx.append(str(data['index']))
-		ipd_item_mapping_name = frappe.db.get_value('IPD Item Mapping',{'item_production_details':doc.item_production_detail},'name')
-		ipd_items = frappe.get_list("Item Mapping", filters={'parent': ['in',ipd_item_mapping_name],'input_index':data['index']}, fields='item')
-		if not ipd_items:
-			ipd_items = frappe.get_list("Item Mapping", filters={'parent': ['in',ipd_item_mapping_name],'input_index':','.join(combined_input_idx)}, fields='item')
-			if ipd_items:
-				combined_input_idx = []
-		ipd_item_list = []
-		for item in ipd_items:
-			ipd_item_list.append(item['item'])
 		for dia in data['dia']:
 			dia_list = [0]*(len(colour_list)+2)
 			dia_list[0] = dia
@@ -280,18 +275,21 @@ def cloth_qty(doc):
 				for item in final_item_list:
 					item_doc = frappe.get_doc("Item",item['item_code'])
 					item_attr = get_attr_dict(item_doc.attributes)
-					if (colour==item_attr['Apparelo Colour'][0]) and (dia==item_attr['Dia'][0]) and (item['item_code'] in ipd_item_list):
-						if input_qty < colour_count and item['qty']:
-							combination_count = find_combination(colour_count, input_qty)
-							qty = round(item['qty']/combination_count,3)
-							dia_list[colour_list.index(colour)+1] = qty
-							dia_total += qty
-						else:
-							dia_list[colour_list.index(colour)+1] = item['qty']
-							dia_total += item['qty']
-						if 'FOLD' in item['item_code']:
-							dia_list[0] = f'{dia} (FOLD)'
-						break
+					bom = frappe.db.get_value('BOM',{'item':item['item_code']},'name')
+					is_yarn_exist = frappe.db.get_value('BOM Explosion Item',{'parent':bom,'item_code':data['yarn']})
+					if is_yarn_exist:
+						if (colour==item_attr['Apparelo Colour'][0]) and (dia==item_attr['Dia'][0]) and (item['item_code'] in data['out_items']):
+							if input_qty < colour_count and item['qty']:
+								combination_count = find_combination(colour_count, input_qty)
+								qty = round(item['qty']/combination_count,3)
+								dia_list[colour_list.index(colour)+1] = qty
+								dia_total += qty
+							else:
+								dia_list[colour_list.index(colour)+1] = item['qty']
+								dia_total += item['qty']
+							if 'FOLD' in item['item_code']:
+								dia_list[0] = f'{dia} (FOLD)'
+							break
 			dia_list[len(colour_list)+1] = round(dia_total,3)
 			dia_qty_list.append(dia_list)
 		for lists in dia_qty_list:

--- a/apparelo/apparelo/doctype/steaming/steaming.py
+++ b/apparelo/apparelo/doctype/steaming/steaming.py
@@ -19,19 +19,21 @@ class Steaming(Document):
 	def create_variants(self, input_item_names):
 		new_variants=[]
 		input_items = []
+		apparelo_colours = []
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
-		attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes, input_items)))
-		variants = create_variants('Steamed Cloth', attribute_set)
-		for variant in variants:
-			variant_doc=frappe.get_doc("Item",variant)
+		for item in input_items:
+			attribute_set = get_item_attribute_set(list(map(lambda x: x.attributes,[item])))
+			apparelo_colours.extend(attribute_set['Apparelo Colour'])
+			variant = create_variants('Steamed Cloth', attribute_set)
+			variant_doc=frappe.get_doc("Item",variant[0])
 			variant_attr = get_attr_dict(variant_doc.attributes)
-			new_variants.append(customize_pf_item_code('Steamed Cloth', attribute_set, variant_attr, variant))
+			new_variants.append(customize_pf_item_code('Steamed Cloth', attribute_set, variant_attr, variant[0]))
 		if len(new_variants)==0:
 			new_variants=variants
-		return new_variants, attribute_set
+		return new_variants, set(apparelo_colours)
 
-	def create_boms(self, input_item_names, variants, attribute_set,item_size,colour,piece_count):
+	def create_boms(self, input_item_names, variants, apparelo_colours,item_size,colour,piece_count):
 		input_items = []
 		for input_item_name in input_item_names:
 			input_items.append(frappe.get_doc('Item', input_item_name))
@@ -41,7 +43,7 @@ class Steaming(Document):
 			for variant in variants:
 				variant_doc=frappe.get_doc("Item",variant)
 				variant_attr = get_attr_dict(variant_doc.attributes)
-				for color in attribute_set['Apparelo Colour']:
+				for color in apparelo_colours:
 					for dia in self.dia_conversions:
 						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
 							bom_for_variant = frappe.get_doc({

--- a/apparelo/apparelo/doctype/steaming/steaming.py
+++ b/apparelo/apparelo/doctype/steaming/steaming.py
@@ -45,7 +45,9 @@ class Steaming(Document):
 				variant_attr = get_attr_dict(variant_doc.attributes)
 				for color in apparelo_colours:
 					for dia in self.dia_conversions:
-						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"]:
+						if color in input_attr["Apparelo Colour"] and color in variant_attr["Apparelo Colour"] \
+							and dia.from_dia in input_attr["Dia"] and dia.from_dia in variant_attr["Dia"] \
+							and input_attr['Knitting Type'] == variant_attr['Knitting Type']:
 							bom_for_variant = frappe.get_doc({
 								"doctype": "BOM",
 								"currency": get_default_currency(),

--- a/apparelo/apparelo/doctype/stitching/stitching.py
+++ b/apparelo/apparelo/doctype/stitching/stitching.py
@@ -75,7 +75,8 @@ class Stitching(Document):
 										frappe.throw(_("Item colour is not available"))
 						variant_attribute_set['Apparelo Size'] = attribute_set["Apparelo Size"]
 					else:
-						frappe.throw(_("Part Colour is not available in the input"))
+						apparelo_colour = attribute_set["Apparelo Colour"]
+						frappe.throw(_(f"Part Colour {colour_mapping.part_colour} is not available in the input item colours {apparelo_colour}"))
 		if self.enable_set_item:
 			variant_attribute_set['Part'] = [self.part]
 		if final_process=="Stitching":


### PR DESCRIPTION
This PR achieves below mentioned,
- Validate whether the final item linked is a template.
- Create variants in compacting, steaming using individual item attributes.
- Fix duplication and unordered values after using cutting helpers.
- Make Js called py function as whitelisted.
- Option given to create GRN from DC.
- Yarnwise qty error fixed in the lot.
- Secondary UOM key error fixed in GRN.
- Validate knitting type while creating BOMs in compacting, steaming.
- Exact color and dia added to error msg of cutting BOM creation.
- Input color attribute added to stitching variant creation error msg.
- Common function used for renaming - Roll printing